### PR TITLE
Log warning for WMSServiceExceptions

### DIFF
--- a/src/main/java/org/geolatte/mapserver/servlet/WMSServlet.java
+++ b/src/main/java/org/geolatte/mapserver/servlet/WMSServlet.java
@@ -31,6 +31,7 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.List;
 
 /**
  * Servlet for WMS requests.
@@ -58,6 +59,12 @@ public class WMSServlet extends HttpServlet {
             response.setContentType(wmsRequest.getResponseContentType());
             wmsService.handle(wmsRequest, response.getOutputStream());
         } catch (WMSServiceException se) {
+            List<String> codes = se.getCodes();
+            if (!codes.isEmpty()) {
+                LOGGER.warn(codes);
+            } else {
+                LOGGER.warn(se.getMessage(), se);
+            }
             //Note that this ignores the EXCEPTIONS Request Parameter!!
             response.setContentType(OGCMIMETypes.SERVICE_EXCEPTION_XML);
             se.writeToOutputStream(response.getOutputStream());

--- a/src/main/java/org/geolatte/mapserver/wms/WMSGetMapRequestHandler.java
+++ b/src/main/java/org/geolatte/mapserver/wms/WMSGetMapRequestHandler.java
@@ -21,8 +21,9 @@ package org.geolatte.mapserver.wms;
 
 import org.apache.log4j.Logger;
 import org.geolatte.geom.crs.CrsId;
-import org.geolatte.mapserver.img.JAIImaging;
-import org.geolatte.mapserver.tms.*;
+import org.geolatte.mapserver.tms.TileImage;
+import org.geolatte.mapserver.tms.TileMap;
+import org.geolatte.mapserver.tms.TileMapRegistry;
 import org.geolatte.mapserver.util.Chrono;
 
 import java.io.IOException;
@@ -47,7 +48,7 @@ public class WMSGetMapRequestHandler implements WMSRequestHandler {
         WMSGetMapRequest request = (WMSGetMapRequest) wmsRequest;
         WMSCapabilities.check(request);
         TileMap tileMap = getTileMapAndCheck(request);
-        LOGGER.info("GetMap Request received: " + request.toString());
+        LOGGER.debug("GetMap Request received: " + request.toString());
         try {
             TileImage image = getMapImage(request, tileMap);
             chrono.reset();
@@ -56,7 +57,7 @@ public class WMSGetMapRequestHandler implements WMSRequestHandler {
         } catch (Exception e) { //TODO: don't catch on class 'Exception'
             throw new WMSServiceException(e.getMessage(),e);
         }
-        LOGGER.info("Response in " + chrono.total() + " ms.");
+        LOGGER.debug("Response in " + chrono.total() + " ms.");
     }
 
     private TileImage getMapImage(WMSGetMapRequest request, TileMap tileMap) throws WMSServiceException {

--- a/src/main/java/org/geolatte/mapserver/wms/WMSServiceException.java
+++ b/src/main/java/org/geolatte/mapserver/wms/WMSServiceException.java
@@ -78,8 +78,7 @@ public class WMSServiceException extends Exception {
 
     private void addExceptions(ServiceExceptionReport report) {
         if (exceptionItems == null || exceptionItems.isEmpty()) {
-            String message = this.getMessage();
-            addException(report, this.getMessage(), null);
+            addException(report, getMessage(), null);
         } else {
             for (WMSServiceExceptionList.Item item : exceptionItems) {
                 addException(report, item.getMessage(), item.getCode());


### PR DESCRIPTION
If the error code is known, just log that code,
else log the error message and stack trace.
Also reduced logging on INFO level (no timings)
